### PR TITLE
Compare version MariaDB server

### DIFF
--- a/upload/source/class/db/db_driver_mysql.php
+++ b/upload/source/class/db/db_driver_mysql.php
@@ -88,10 +88,10 @@ class db_driver_mysql
 			$halt && $this->halt('notconnect', $this->errno());
 		} else {
 			$this->curlink = $link;
-			if($this->version() > '4.1') {
+			if(version_compare($this->version(), '4.1', '>')) {
 				$dbcharset = $dbcharset ? $dbcharset : $this->config[1]['dbcharset'];
 				$serverset = $dbcharset ? 'character_set_connection='.$dbcharset.', character_set_results='.$dbcharset.', character_set_client=binary' : '';
-				$serverset .= $this->version() > '5.0.1' ? ((empty($serverset) ? '' : ',').'sql_mode=\'\'') : '';
+				$serverset .= version_compare($this->version(), '5.0.1', '>') ? ((empty($serverset) ? '' : ',').'sql_mode=\'\'') : '';
 				$serverset && mysql_query("SET $serverset", $link);
 			}
 			$dbname && @mysql_select_db($dbname, $link);


### PR DESCRIPTION
Use version_compare() for checking mysql server version instead, current compare method is not compatible with MariaDB since it compares ASCI strings instead of version numbers.

Example: 
```
# cat test.php
<?php
var_dump('10.6.12-MariaDB-cll-lve' > '5.6');
var_dump('5.7.41-cll-lve' > '5.6');
```
returns:
```
# php test.php
bool(false)
bool(true)
```